### PR TITLE
修复没有创建分类或标签时复无法生成的问题

### DIFF
--- a/layouts/partials/sidebar/state.html
+++ b/layouts/partials/sidebar/state.html
@@ -6,15 +6,24 @@
       </a>
     </div>
     <div class="site-state-item site-state-categories">    
-        <a href="/categories/">       
-        <span class="site-state-item-count">{{ len .Site.Taxonomies.categories }}</span>
+        <a href="/categories/">      
+        {{if isset .Site.Taxonomies "categories"}} 
+        <span class="site-state-item-count">{{len .Site.Taxonomies.categories}}</span>
+        {{else}}
+        <span class="site-state-item-count">0</span>
+        {{end}}
         <span class="site-state-item-name">{{ i18n "Category" }}</span>
+        
         </a>
     </div>
 
     <div class="site-state-item site-state-tags">
         <a href="/tags/">
-        <span class="site-state-item-count">{{ len .Site.Taxonomies.tags }}</span>
+        {{if isset .Site.Taxonomies "tags"}} 
+        <span class="site-state-item-count">{{len .Site.Taxonomies.tags}}</span>
+        {{else}}
+        <span class="site-state-item-count">0</span>
+        {{end}}
         <span class="site-state-item-name">{{ i18n "Tag" }}</span>
         </a>
     </div>


### PR DESCRIPTION
> 修复bug

在最新版hugo
当 .Site.Taxonomies.categories == nil or .Site.Taxonomies.tags == nil 时
生成博客会出现 len typed nil error，
进行一次判断即可