### PR TITLE
 Add pygmentsCodefences config to support markdown code syntax

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,7 +12,8 @@ HasCJKLanguage = true
 PreserveTaxonomyNames = false
 UglyUrls = false
 PygmentsStyle = "monokai"
-PygmentsUseClasses = true
+pygmentsCodefences = true
+pygmentsCodefencesGuessSyntax = true
 DefaultContentLanguage = "zh"
 
 [Params]


### PR DESCRIPTION
1. Add pygmentsCodefences* to support markdown code syntax like:
 \```go
\//code
\```

2. Remove PygmentsUseClasses to fix issue of PygmentsStyle change not work.
Available style value please check https://help.farbox.com/pygments.html