### PR TITLE
use global hugo function,.URL is deprecated,.RSSLink deprecated

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,7 +5,7 @@
   <span class="author" itemprop="copyrightHolder">{{ .Site.Title }}</span>
 </div>
 <div class="powered-by">
-  Powered by - <a class="theme-link" href="http://gohugo.io" target="_blank" title="hugo" >Hugo v{{ .Hugo.Version }}</a>
+  Powered by - <a class="theme-link" href="http://gohugo.io" target="_blank" title="hugo" >Hugo v{{ hugo.Version }}</a>
 </div>
 <div class="theme-info">
   Theme by - <a class="theme-link" href="https://github.com/xtfly/hugo-theme-next" target="_blank"> NexT

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,17 +4,17 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" /> 
-    <title>{{ if ne .URL " / " }}{{ .Title }} - {{ end }}{{ .Site.Title }}</title>
+    <title>{{ if ne .Permalink " / " }}{{ .Title }} - {{ end }}{{ .Site.Title }}</title>
     {{ if .Keywords }}<meta name="keywords" content="{{ range .Keywords }}{{ . }},{{ end }}">
     {{ else }}<meta name="keywords" content="{{ .Site.Params.Keywords }}">{{ end }}
     {{ with .Site.Author.Name }}<meta name="author" content="{{ . }}">{{ end }}
-    <meta property="og:title" content="{{ if ne .URL " / " }}{{ .Title }}{{else}}{{ .Site.Title }}{{end}}">
+    <meta property="og:title" content="{{ if ne .Permalink " / " }}{{ .Title }}{{else}}{{ .Site.Title }}{{end}}">
     <meta property="og:site_name" content="{{ .Site.Title }}">
     <meta property="og:image" content="/img/author.jpg"> 
-    <meta name="title" content="{{ if ne .URL " / " }}{{ .Title }} - {{ end }}{{ .Site.Title }}" />
+    <meta name="title" content="{{ if ne .Permalink " / " }}{{ .Title }} - {{ end }}{{ .Site.Title }}" />
     {{ with .Description }}<meta name="description" content="{{ . }}" />
     {{ else }}<meta name="description" content="{{ .Site.Params.Description }}">{{ end }} 
-    {{ if .RSSLink }}<link rel="alternate" href="{{.RSSLink}}" title="{{ .Site.Title }}" type="application/rss+xml" />{{ end }}
+    {{ if .RelPermalink }}<link rel="alternate" href="{{.RelPermalink}}" title="{{ .Site.Title }}" type="application/rss+xml" />{{ end }}
     <link rel="shortcut icon" href="/img/favicon.ico" />
     <link rel="apple-touch-icon" href="/img/apple-touch-icon.png" />
     <link rel="apple-touch-icon-precomposed" href="/img/apple-touch-icon.png" />

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -23,7 +23,7 @@
       {{ $currentPage := . }}
       {{ range .Site.Menus.main }}
         <li class="menu-item {{ if $currentPage.IsMenuCurrent "main" . }}menu-item-active{{ end }}">
-          <a href="{{ .URL }}" rel="section">
+          <a href="{{ .Pre }}" rel="section">
               <i class="menu-item-icon fa fa-fw fa-{{ .Pre }}"></i> <br />{{ .Name }}
           </a>
         </li>

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -21,15 +21,15 @@
 {{ $begin := $.Scratch.Get "begin"}}
 
 <nav class="pagination">
-    {{ if $pag.HasPrev }}<a class="extend prev" rel="prev" href="{{ $pag.Prev.URL  }}"><i class="fa fa-angle-left"></i></a>{{ end }}
+    {{ if $pag.HasPrev }}<a class="extend prev" rel="prev" href="{{ $pag.Prev.RelPermalink  }}"><i class="fa fa-angle-left"></i></a>{{ end }}
     {{ range $p := $pag.Pagers }}
         {{ if and (ge $p.PageNumber $begin) (le $p.PageNumber $end) }}
         {{ if eq $p $pag }}
           <span class="page-number current">{{ $p.PageNumber }}</span>
         {{ else }}
-          <a class="page-number" href="{{ $p.URL  }}">{{ $p.PageNumber }}</a>
+          <a class="page-number" href="{{ $p.RelPermalink  }}">{{ $p.PageNumber }}</a>
         {{ end }}
         {{ end }}
     {{ end }}
-    {{ if $pag.HasNext }}<a class="extend next" rel="next" href="{{ $pag.Next.URL }}"><i class="fa fa-angle-right"></i></a>{{ end }}
+    {{ if $pag.HasNext }}<a class="extend next" rel="next" href="{{ $pag.Next.RelPermalink }}"><i class="fa fa-angle-right"></i></a>{{ end }}
 </nav>

--- a/layouts/partials/sidebar/link.html
+++ b/layouts/partials/sidebar/link.html
@@ -7,7 +7,7 @@
     <ul class="links-of-blogroll-list">
         {{ range .Site.Params.Links }}
         <li class="links-of-blogroll-item">
-            <a href="{{ .URL }}" title="{{ .Name }}" target="_blank">{{ .Name }}</a>
+            <a href="{{ .Permalink }}" title="{{ .Name }}" target="_blank">{{ .Name }}</a>
         </li>
         {{ end }}
     </ul>

--- a/layouts/partials/sidebar/rss.html
+++ b/layouts/partials/sidebar/rss.html
@@ -1,6 +1,6 @@
-{{ if .RSSLink }}
+{{ if .RelPermalink }}
 <div class="feed-link motion-element">
-<a href="{{.RSSLink}}" rel="alternate" type="application/rss+xml" target="_blank">
+<a href="{{.RelPermalink}}" rel="alternate" type="application/rss+xml" target="_blank">
     <i class="fa fa-rss"></i>
     {{ i18n "RSS" }}
 </a>

--- a/layouts/partials/sidebar/social.html
+++ b/layouts/partials/sidebar/social.html
@@ -2,7 +2,7 @@
 <div class="links-of-author motion-element">
     {{ range .Site.Params.Socials }}
         <span class="links-of-author-item">
-        <a href="{{ .URL }}" target="_blank" title="{{ .Name }}">
+        <a href="{{ .Permalink }}" target="_blank" title="{{ .Name }}">
             <i class="fa fa-fw fa-{{ .Icon }}"></i>
             {{ .Name }}
         </a>


### PR DESCRIPTION
starting with hugo v 0.55, you'll get 

` Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.`
` Page's .RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like: 
    {{ with .OutputFormats.Get "RSS" }}{{ . RelPermalink }}{{ end }}.`

and 

` Page's .URL is deprecated and will be removed in a future release. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url.`

this fixes it.

